### PR TITLE
Fix: Transaction User creation and exp value #20

### DIFF
--- a/app_server/src/error.rs
+++ b/app_server/src/error.rs
@@ -10,6 +10,7 @@ pub enum ServerError {
     DailyError(DailyMissionServiceError),
     UserExp(ExpServiceError),
     UserErr(UserServiceError),
+    Transaction(String),
 }
 
 impl IntoResponse for ServerError {
@@ -56,6 +57,7 @@ impl IntoResponse for ServerError {
                 }
                 _ => (StatusCode::INTERNAL_SERVER_ERROR).into_response(),
             },
+            Self::Transaction(_) => (StatusCode::INTERNAL_SERVER_ERROR).into_response()
         }
     }
 }

--- a/domain/src/repository/user_exp_repository.rs
+++ b/domain/src/repository/user_exp_repository.rs
@@ -1,5 +1,7 @@
 use std::{future::Future, pin::Pin};
 
+use sqlx::{MySql, Transaction};
+
 use crate::entity::{user_exp::UserExp, user_id::UserId};
 
 use super::repository_error::RepositoryError;
@@ -9,10 +11,11 @@ use super::repository_error::RepositoryError;
 pub trait UserExpRepository {
     /// UserExpを初期化(データベースに登録する)
     /// そのため各ユーザー
-    fn init_exp(
-        &self,
-        user_id: &UserId,
-    ) -> Pin<Box<dyn Future<Output = Result<(), RepositoryError>> + Send + 'static>>;
+    fn init_exp<'a>(
+        &'a self,
+        tx: &'a mut Transaction<'_, MySql>,
+        user_id: &'a UserId,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RepositoryError>> + Send + 'a>>;
 
     /// UserExpを取得する
     fn find_by_user_id(

--- a/domain/src/repository/user_repository.rs
+++ b/domain/src/repository/user_repository.rs
@@ -1,5 +1,7 @@
 use std::{future::Future, pin::Pin};
 
+use sqlx::{MySql, Transaction};
+
 use crate::entity::{user::User, user_builder::UserBuilder, user_id::UserId};
 
 use super::repository_error::RepositoryError;
@@ -8,10 +10,11 @@ use super::repository_error::RepositoryError;
 /// UserRepositoryの実装はinfrastructureで行う
 pub trait UserRepository {
     /// Userデータを保存する
-    fn create(
-        &self,
-        user_builder: &UserBuilder,
-    ) -> Pin<Box<dyn Future<Output = Result<UserId, RepositoryError>> + Send + 'static>>;
+    fn create<'a>(
+        &'a self,
+        tx: &'a mut Transaction<'_, MySql>,
+        user_builder: &'a UserBuilder,
+    ) -> Pin<Box<dyn Future<Output = Result<UserId, RepositoryError>> + Send + 'a>>;
 
     /// UserIdによってUserデータを取得する
     fn find_by_id(

--- a/domain/src/service/user_exp_service.rs
+++ b/domain/src/service/user_exp_service.rs
@@ -1,3 +1,5 @@
+use sqlx::{MySql, Transaction};
+
 use crate::{
     entity::{token::Token, user_id::UserId, user_level::UserLevel},
     repository::user_exp_repository::UserExpRepository,
@@ -35,9 +37,9 @@ where
     }
     
     // ユーザー作成時に経験値のDBテーブルに対して、ユーザーのレコードを作成(1回だけ)
-    // TODO: 引数に(tx: sqlx::Transaction)をとり、ユーザー作成と経験値テーブル初期化をトランザクションで行う
-    pub async fn init_exp(&self, user_id: UserId) -> Result<(), ExpServiceError> {
-        self.exp_repo.init_exp(&user_id).await?;
+    // UserService::create()とともにトランザクションで処理するため Transaction型を引数に取っている
+    pub async fn init_exp<'a>(&'a self, tx: &'a mut Transaction<'_, MySql>, user_id: UserId) -> Result<(), ExpServiceError> {
+        self.exp_repo.init_exp(tx, &user_id).await?;
         Ok(())
     }
 


### PR DESCRIPTION
#20 
## Chenged 
UserRepository::create() and UserExpRepository::init_exp() have Transaction type.
```rust
pub trait UserExpRepository {
    fn init_exp<'a>(
//             ++++
        &'a self,
        tx: &'a mut Transaction<'_, MySql>,
//                      ++++++++++++++++
        user_id: &'a UserId,
    ) -> Pin<Box<dyn Future<Output = Result<(), RepositoryError>> + Send + 'a>>;
```