### PR TITLE
 Changed to limit the number of daily mission registrations

### DIFF
--- a/app_server/src/error.rs
+++ b/app_server/src/error.rs
@@ -38,6 +38,9 @@ impl IntoResponse for ServerError {
                 DailyMissionServiceError::RepositoryError(_) => {
                     (StatusCode::INTERNAL_SERVER_ERROR).into_response()
                 }
+                DailyMissionServiceError::OverCapacity => {
+                    (StatusCode::BAD_REQUEST).into_response()
+                }
                 DailyMissionServiceError::UnknownError(_) => {
                     (StatusCode::INTERNAL_SERVER_ERROR).into_response()
                 }

--- a/domain/src/repository/daily_mission_repository.rs
+++ b/domain/src/repository/daily_mission_repository.rs
@@ -17,6 +17,12 @@ pub trait DailyMissionRepository {
         builder: &'a DailyMission,
     ) -> Pin<Box<dyn Future<Output = Result<DailyMissionId, RepositoryError>> + Send + 'a>>;
 
+    /// ユーザーが登録したミッションがいくつあるのかカウントするメソッド
+    fn count<'a>(
+        &'a self,
+        user_id: &'a UserId
+    ) -> Pin<Box<dyn Future<Output = Result<i32, RepositoryError>> + Send + 'a>>;
+
     /// DailyMissionIdを使用して一つのDailyMissionデータを取得する
     fn find_by_id<'a>(
         &'a self,

--- a/domain/src/service/daily_mission_service.rs
+++ b/domain/src/service/daily_mission_service.rs
@@ -45,6 +45,14 @@ where
         mission_payload: DailyMissionInput,
     ) -> Result<DailyMissionId, DailyMissionServiceError> {
         let user_id = self.token_service.verify(token)?;
+        let length = self.mission_repo.count(&user_id).await?;
+
+        // ユーザーは最大7個まで登録することができる
+        // 7個になったら追加できないようにguardする
+        if length >= 7 {
+            return Err(DailyMissionServiceError::OverCapacity);
+        }
+        
         let mission_id = DailyMissionId(self.uuid_service.generate());
         let mission = DailyMissionBuilder::new()
             .user_id(&user_id)

--- a/domain/src/service/service_error/daily_mission_service_error.rs
+++ b/domain/src/service/service_error/daily_mission_service_error.rs
@@ -12,6 +12,8 @@ pub enum DailyMissionServiceError {
     RepositoryError(RepositoryError),
     #[error("Invalid input: {0}")]
     InvalidInput(TokenServiceError),
+    #[error("Stored Daily Mission is full")]
+    OverCapacity,
     #[error("Unknown error: {0}")]
     UnknownError(String),
 }


### PR DESCRIPTION
## Chenged
- fix ```DailyMissionRepository``` trait define to have ```create()``` method
```rust
pub trait DailyMissionRepository {
    /// ユーザーが登録したミッションがいくつあるのかカウントするメソッド
    fn count<'a>(
        &'a self,
        user_id: &'a UserId
    ) -> Pin<Box<dyn Future<Output = Result<i32, RepositoryError>> + Send + 'a>>;
   .
   .
   .
}
```
- check sotred daily mission length at ```DailyMissionService```
```rust
    pub async fn create(
        &self,
        token: Token,
        mission_payload: DailyMissionInput,
    ) -> Result<DailyMissionId, DailyMissionServiceError> {
        let user_id = self.token_service.verify(token)?;
        let length = self.mission_repo.count(&user_id).await?;

        // ユーザーは最大7個まで登録することができる
        // 7個になったら追加できないようにguardする
        if length >= 7 {
            return Err(DailyMissionServiceError::OverCapacity);
        }
        
        let mission_id = DailyMissionId(self.uuid_service.generate());
        let mission = DailyMissionBuilder::new()
            .user_id(&user_id)
            .mission_id(&mission_id)
            .title(&mission_payload.title)
            .description(&mission_payload.description)
            .build();

        let mission_id = self.mission_repo.create(&mission).await?;
        Ok(mission_id)
    }
```