### PR TITLE
Implmentation of validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +404,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +488,7 @@ dependencies = [
  "serde",
  "sqlx",
  "thiserror 2.0.7",
+ "validator",
 ]
 
 [[package]]
@@ -928,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1431,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1508,35 @@ checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
@@ -1942,6 +2044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2418,36 @@ checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
  "rand",
+]
+
+[[package]]
+name = "validator"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac855a2ce6f843beb229757e6e570a42e837bcb15e5f449dd48d5747d41bf77"
+dependencies = [
+ "darling",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/app_server/src/error.rs
+++ b/app_server/src/error.rs
@@ -41,6 +41,9 @@ impl IntoResponse for ServerError {
                 DailyMissionServiceError::OverCapacity => {
                     (StatusCode::BAD_REQUEST).into_response()
                 }
+                DailyMissionServiceError::Validate(_) => {
+                    (StatusCode::BAD_REQUEST).into_response()
+                }
                 DailyMissionServiceError::UnknownError(_) => {
                     (StatusCode::INTERNAL_SERVER_ERROR).into_response()
                 }
@@ -58,7 +61,18 @@ impl IntoResponse for ServerError {
                 UserServiceError::RepositoryError(_) => {
                     (StatusCode::INTERNAL_SERVER_ERROR).into_response()
                 }
-                _ => (StatusCode::INTERNAL_SERVER_ERROR).into_response(),
+                UserServiceError::HashError(_) => {
+                    (StatusCode::INTERNAL_SERVER_ERROR).into_response()
+                }
+                UserServiceError::TokenError(_) => {
+                    (StatusCode::UNAUTHORIZED).into_response()
+                }
+                UserServiceError::UserAlreadyExists => {
+                    (StatusCode::BAD_REQUEST).into_response()
+                }
+                UserServiceError::Validation(_) => {
+                    (StatusCode::BAD_REQUEST).into_response()
+                }
             },
             Self::Transaction(_) => (StatusCode::INTERNAL_SERVER_ERROR).into_response()
         }

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 thiserror = "2.0.7"
 serde ={ workspace = true }
 sqlx = { workspace = true }
+validator = { version = "0.19.0", features = ["derive"] }

--- a/domain/src/entity/daily_mission_input.rs
+++ b/domain/src/entity/daily_mission_input.rs
@@ -1,7 +1,10 @@
 use serde::Deserialize;
+use validator::Validate;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Validate)]
 pub struct DailyMissionInput {
+    #[validate(length(min = 1, max = 20))]
     pub title: String,
+    #[validate(length(max = 100))]
     pub description: Option<String>,
 }

--- a/domain/src/entity/user_input.rs
+++ b/domain/src/entity/user_input.rs
@@ -1,9 +1,13 @@
 use serde::Deserialize;
+use validator::Validate;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct UserInput {
+    #[validate(length(min = 1, max = 10))]
     pub user_name: String,
+    #[validate(email)]
     pub email: String,
+    #[validate(length(min = 8, max = 15))]
     pub password: String,
 }

--- a/domain/src/service/daily_mission_service.rs
+++ b/domain/src/service/daily_mission_service.rs
@@ -1,4 +1,5 @@
 use sqlx::{MySql, Transaction};
+use validator::Validate;
 
 use crate::{
     entity::{
@@ -45,6 +46,9 @@ where
         mission_payload: DailyMissionInput,
     ) -> Result<DailyMissionId, DailyMissionServiceError> {
         let user_id = self.token_service.verify(token)?;
+        // バリデーション
+        mission_payload.validate().map_err(|e| DailyMissionServiceError::Validate(e))?;
+        // ユーザーが登録しているデイリーミッションをカウント
         let length = self.mission_repo.count(&user_id).await?;
 
         // ユーザーは最大7個まで登録することができる

--- a/domain/src/service/service_error/daily_mission_service_error.rs
+++ b/domain/src/service/service_error/daily_mission_service_error.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use validator::ValidationErrors;
 
 use crate::repository::repository_error::RepositoryError;
 
@@ -14,6 +15,8 @@ pub enum DailyMissionServiceError {
     InvalidInput(TokenServiceError),
     #[error("Stored Daily Mission is full")]
     OverCapacity,
+    #[error("Validation error: {0}")]
+    Validate(ValidationErrors),
     #[error("Unknown error: {0}")]
     UnknownError(String),
 }

--- a/domain/src/service/service_error/user_service_error.rs
+++ b/domain/src/service/service_error/user_service_error.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use validator::ValidationErrors;
 
 use super::{hash_error::HashServiceError, token_service_error::TokenServiceError};
 use crate::repository::repository_error::RepositoryError;
@@ -9,10 +10,12 @@ pub enum UserServiceError {
     HashError(String),
     #[error("Repository error: {0}")]
     RepositoryError(String),
-    #[error("user already exists")]
+    #[error("User already exists")]
     UserAlreadyExists,
-    #[error("token error: {0}")]
+    #[error("Token error: {0}")]
     TokenError(TokenServiceError),
+    #[error("Validation error: {0}")]
+    Validation(ValidationErrors),
 }
 
 impl From<HashServiceError> for UserServiceError {

--- a/domain/src/service/user_service.rs
+++ b/domain/src/service/user_service.rs
@@ -1,4 +1,5 @@
 use sqlx::{MySql, Transaction};
+use validator::Validate;
 
 use crate::{
     entity::{
@@ -45,6 +46,8 @@ where
 
     // UserExpService::init_exp()とともにトランザクションで処理するため、Transaction型を引数に取っている
     pub async fn create_user<'a>(&'a self, tx: &'a mut Transaction<'_, MySql>, user_input: UserInput) -> Result<UserId, UserServiceError> {
+        // 入力のバリデーション
+        user_input.validate().map_err(|e| UserServiceError::Validation(e))?;
         // ユーザーが既に存在するか確認
         // trueの場合は既に存在するため早期リターン
         if self.user_repo.is_exist(&user_input.email).await? {


### PR DESCRIPTION
Changed to validate against user input  
derive Validate trait
```rust
#[derive(Debug, Clone, Deserialize, Validate)]
#[serde(rename_all = "camelCase")]
pub struct UserInput {
    #[validate(length(min = 1, max = 10))]
    pub user_name: String,
    #[validate(email)]
    pub email: String,
    #[validate(length(min = 8, max = 15))]
    pub password: String,
}
```
And validation at service layer
```rust
pub async fn create_user<'a>(&'a self, tx: &'a mut Transaction<'_, MySql>, user_input: UserInput) -> Result<UserId, UserServiceError> {
  // 入力のバリデーション
  user_input.validate().map_err(|e| UserServiceError::Validation(e))?;
  // ユーザーが既に存在するか確認
  // trueの場合は既に存在するため早期リターン
  if self.user_repo.is_exist(&user_input.email).await? {
      return Err(UserServiceError::UserAlreadyExists);
  }
}

```