### PR TITLE
Fix server response error type

### DIFF
--- a/app_server/src/error.rs
+++ b/app_server/src/error.rs
@@ -1,12 +1,16 @@
-use axum::{http::StatusCode, response::IntoResponse};
-use domain::service::service_error::{
-    auth_service_error::AuthServiceError, daily_mission_service_error::DailyMissionServiceError,
-    exp_error::ExpServiceError, user_service_error::UserServiceError,
+use axum::{http::StatusCode, response::IntoResponse, Json};
+use domain::{
+    repository::repository_error::RepositoryError,
+    service::service_error::{
+        auth_service_error::AuthServiceError,
+        daily_mission_service_error::DailyMissionServiceError, exp_error::ExpServiceError,
+        token_service_error::TokenServiceError, user_service_error::UserServiceError,
+    },
 };
+use serde::Serialize;
 
 #[derive(Debug, Clone)]
 pub enum ServerError {
-    AuthError(AuthServiceError),
     DailyError(DailyMissionServiceError),
     UserExp(ExpServiceError),
     UserErr(UserServiceError),
@@ -16,18 +20,6 @@ pub enum ServerError {
 impl IntoResponse for ServerError {
     fn into_response(self) -> axum::response::Response {
         match self {
-            Self::AuthError(e) => match e {
-                AuthServiceError::CreateToken(_) => {
-                    (StatusCode::INTERNAL_SERVER_ERROR).into_response()
-                }
-                AuthServiceError::WrongPassword => (StatusCode::UNAUTHORIZED).into_response(),
-                AuthServiceError::HashError(_) => {
-                    (StatusCode::INTERNAL_SERVER_ERROR).into_response()
-                }
-                AuthServiceError::RepositoryError(_) => {
-                    (StatusCode::INTERNAL_SERVER_ERROR).into_response()
-                }
-            },
             Self::DailyError(e) => match e {
                 DailyMissionServiceError::AuthError(_) => {
                     (StatusCode::UNAUTHORIZED).into_response()
@@ -65,6 +57,94 @@ impl IntoResponse for ServerError {
                 UserServiceError::Validation(_) => (StatusCode::BAD_REQUEST).into_response(),
             },
             Self::Transaction(_) => (StatusCode::INTERNAL_SERVER_ERROR).into_response(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Error {
+    code: u32,
+    message: String,
+}
+
+impl Error {
+    fn new(code: u32, message: &str) -> Self {
+        Self {
+            code,
+            message: message.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum AuthError {
+    DataMismatch,
+    InvalidData,
+    InvalidToken,
+    WrongPassword,
+    Server,
+    TokenExpired,
+    UserNotFound,
+}
+
+impl From<AuthServiceError> for AuthError {
+    fn from(value: AuthServiceError) -> Self {
+        match value {
+            AuthServiceError::WrongPassword => AuthError::WrongPassword,
+            AuthServiceError::RepositoryError(v) => match v {
+                RepositoryError::NotFound => AuthError::UserNotFound,
+                RepositoryError::InvalidData(_) => AuthError::InvalidData,
+                RepositoryError::DatabaseError(_) => AuthError::Server,
+            },
+            AuthServiceError::CreateToken(e) => match e {
+                TokenServiceError::TokenInvalid(_) => AuthError::InvalidToken,
+                TokenServiceError::TokenExpired => AuthError::TokenExpired,
+                TokenServiceError::DataMismatch(_) => AuthError::DataMismatch,
+                _ => AuthError::Server,
+            },
+            AuthServiceError::HashError(_) => AuthError::Server,
+        }
+    }
+}
+
+impl IntoResponse for AuthError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::DataMismatch => (
+                StatusCode::BAD_REQUEST,
+                Json(Error::new(100, "Data mismatch")),
+            )
+                .into_response(),
+            Self::InvalidData => (
+                StatusCode::BAD_REQUEST,
+                Json(Error::new(101, "Invalid data")),
+            )
+                .into_response(),
+            Self::InvalidToken => (
+                StatusCode::BAD_REQUEST,
+                Json(Error::new(102, "Invalid token")),
+            )
+                .into_response(),
+            Self::WrongPassword => (
+                StatusCode::BAD_REQUEST,
+                Json(Error::new(103, "Wrong password")),
+            )
+                .into_response(),
+            Self::Server => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(Error::new(104, "Server error")),
+            )
+                .into_response(),
+            Self::TokenExpired => (
+                StatusCode::BAD_REQUEST,
+                Json(Error::new(105, "Token expired")),
+            )
+                .into_response(),
+            Self::UserNotFound => (
+                StatusCode::NOT_FOUND,
+                Json(Error::new(106, "User not found")),
+            )
+                .into_response(),
         }
     }
 }

--- a/app_server/src/handlers/auth.rs
+++ b/app_server/src/handlers/auth.rs
@@ -13,13 +13,13 @@ use infrastructure::{
 };
 use sqlx::MySqlPool;
 
-use crate::error::ServerError;
+use crate::error::AuthError;
 
 pub async fn login(
     jar: CookieJar,
     State(pool): State<MySqlPool>,
     Json(auth_payload): Json<AuthRequest>,
-) -> Result<impl IntoResponse, ServerError> {
+) -> Result<impl IntoResponse, AuthError> {
     // ログインサービスのインスタンス化
     let service = AuthService::new(
         PasswordHashServiceImpl,
@@ -28,10 +28,7 @@ pub async fn login(
         token_exp(),
     );
 
-    let token = service
-        .login(auth_payload)
-        .await
-        .map_err(ServerError::AuthError)?;
+    let token = service.login(auth_payload).await?;
 
     let cookie = CookieBuilder::new("token", token.0)
         .http_only(true)


### PR DESCRIPTION
## Chenge
- Added Error type
```rust
struct Error {
    code: u32,
    message: String,
}
```
## LoadMap
- Breaking away from error responses using ServerError
- Implemented so that all services return an error response like the one above.