### PR TITLE
[Fix]Changed logic for resetting daily mission completion attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -1935,6 +1936,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -1976,6 +1978,7 @@ dependencies = [
  "base64 0.22.1",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2011,6 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ members = ["app_server", "mission_resetter", "domain", "infrastructure"]
 [workspace.dependencies]
 dotenvy = "0.15.7"
 serde = { version = "1.0.216", features = ["derive"]}
-sqlx = { version = "0.8.2", features = ["mysql", "runtime-tokio-rustls"]}
+sqlx = { version = "0.8.2", features = ["mysql", "runtime-tokio-rustls", "chrono"]}

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,7 @@ services:
       dockerfile: server.Dockerfile
     ports:
       - 8080:8080
+    command:  sh -c "make && /app/target/release/app_server" 
     depends_on:
       - db
     networks:

--- a/migrations/20241220143229_1.sql
+++ b/migrations/20241220143229_1.sql
@@ -14,9 +14,17 @@ CREATE TABLE daily_mission (
     mission_id  VARCHAR(64) NOT NULL,
     title       VARCHAR(255) NOT NULL,
     descriptions TEXT,
-    is_complete BOOLEAN DEFAULT FALSE,
     PRIMARY KEY (id),
-    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+    UNIQUE INDEX (mission_id)
+);
+
+CREATE TABLE mission_completed (
+    id          INT AUTO_INCREMENT,
+    mission_id  VARCHAR(64) NOT NULL,
+    date        DATE NOT NULL, 
+    PRIMARY KEY (id),
+    FOREIGN KEY (mission_id) REFERENCES daily_mission(mission_id) ON DELETE CASCADE
 );
 
 CREATE TABLE user_exp (

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -25,4 +25,3 @@ COPY ./migrations /app/migrations
 COPY Makefile /app/Makefile
 
 EXPOSE 8080
-CMD [ "sh", "-c", "make && /app/target/release/app_server" ]


### PR DESCRIPTION
## Description
This PR is solve #53. 
Separating table and removing ```resetter_server```, Improve daily_mission data safety.  
## Change
- Remove ```is_complete``` colum from ```daily_mission``` DB's table
- Added new table ```mission_completed``` table
- Fix ```daily_mission_repository``` trait implmentation
